### PR TITLE
Fix config/CLI gather merge and consistent output path roots

### DIFF
--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { loadConfig } from "./config";
+
+describe("loadConfig", () => {
+  const tempRoots: string[] = [];
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+
+    await Promise.all(
+      tempRoots
+        .splice(0)
+        .map((tempRoot) => fs.rm(tempRoot, { recursive: true, force: true })),
+    );
+  });
+
+  it("should track command config directories with project precedence", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "recon-config-"));
+    tempRoots.push(tempRoot);
+
+    const homeDir = path.join(tempRoot, "home");
+    const projectDir = path.join(tempRoot, "project");
+    const nestedProjectDir = path.join(projectDir, "nested", "cwd");
+
+    await fs.mkdir(homeDir, { recursive: true });
+    await fs.mkdir(nestedProjectDir, { recursive: true });
+
+    await fs.writeFile(
+      path.join(homeDir, ".recon.config.mjs"),
+      `export default {
+  commands: {
+    homeOnly: {
+      gather: {
+        files: ["./home.md"],
+      },
+    },
+    shared: {
+      gather: {
+        files: ["./home-shared.md"],
+      },
+    },
+  },
+};`,
+    );
+
+    await fs.writeFile(
+      path.join(projectDir, ".recon.config.mjs"),
+      `export default {
+  commands: {
+    projectOnly: {
+      gather: {
+        files: ["./project.md"],
+      },
+    },
+    shared: {
+      gather: {
+        files: ["./project-shared.md"],
+      },
+    },
+  },
+};`,
+    );
+
+    vi.spyOn(os, "homedir").mockReturnValue(homeDir);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    vi.spyOn(process, "cwd").mockReturnValue(nestedProjectDir);
+
+    const { config, commandConfigDirs, defaultConfigDir } = await loadConfig();
+
+    expect(config.commands?.homeOnly.gather).toEqual({
+      files: ["./home.md"],
+    });
+    expect(config.commands?.projectOnly.gather).toEqual({
+      files: ["./project.md"],
+    });
+    expect(config.commands?.shared.gather).toEqual({
+      files: ["./project-shared.md"],
+    });
+
+    expect(commandConfigDirs).toEqual({
+      homeOnly: homeDir,
+      projectOnly: projectDir,
+      shared: projectDir,
+    });
+    expect(defaultConfigDir).toBe(projectDir);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Warning: Command "shared" is defined in both config files. The command from the project-level config will be used.',
+    );
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,20 +17,26 @@ export interface ReconCommand {
 
 export async function loadConfig(): Promise<{
   config: ReconConfig;
-  configDir?: string;
+  commandConfigDirs: Record<string, string | undefined>;
+  defaultConfigDir?: string;
 }> {
   const homedir = os.homedir();
   const homeConfigPath = path.join(homedir, ".recon.config.mjs");
   let homeConfig: ReconConfig = {};
   let projectConfig: ReconConfig = {};
+  const commandConfigDirs: Record<string, string | undefined> = {};
+  let homeConfigDir: string | undefined;
 
   if (fs.existsSync(homeConfigPath)) {
     homeConfig = (await import(homeConfigPath)).default;
+    homeConfigDir = path.dirname(homeConfigPath);
   }
 
   const projectConfigPath = findProjectConfig(process.cwd());
+  let projectConfigDir: string | undefined;
   if (projectConfigPath) {
     projectConfig = (await import(projectConfigPath)).default;
+    projectConfigDir = path.dirname(projectConfigPath);
   }
 
   const mergedConfig: ReconConfig = {
@@ -51,9 +57,18 @@ export async function loadConfig(): Promise<{
     }
   }
 
+  for (const commandName of Object.keys(homeConfig.commands || {})) {
+    commandConfigDirs[commandName] = homeConfigDir;
+  }
+
+  for (const commandName of Object.keys(projectConfig.commands || {})) {
+    commandConfigDirs[commandName] = projectConfigDir;
+  }
+
   return {
     config: mergedConfig,
-    configDir: projectConfigPath ? path.dirname(projectConfigPath) : undefined,
+    commandConfigDirs,
+    defaultConfigDir: projectConfigDir || homeConfigDir,
   };
 }
 

--- a/src/defaultExclusions.ts
+++ b/src/defaultExclusions.ts
@@ -77,6 +77,8 @@ export const defaultExclusions = [
   "**/*.njsproj",
   "**/*.sln",
   "**/*.sw?",
+  // WSL zone identifier metadata files
+  "**/*:Zone.Identifier",
 
   // Common non-text file types
   "**/*.png",
@@ -110,4 +112,9 @@ export const defaultExclusions = [
   "**/*.ai",
   "**/*.sketch",
   "**/*.fig",
+  "**/*.woff",
+  "**/*.woff2",
+  "**/*.eot",
+  "**/*.ttf",
+  "**/*.otf",
 ];

--- a/src/filesAgent.spec.ts
+++ b/src/filesAgent.spec.ts
@@ -255,6 +255,71 @@ describe("FilesAgent", () => {
     expect(result).toEqual(expected);
   });
 
+  it("should treat directory exclusions as recursive ignore patterns", async () => {
+    vi.mocked(readFile).mockResolvedValue("File content");
+    vi.mocked(stat).mockImplementation(async (filePath) => {
+      if (filePath === "./docs" || filePath === "docs/private") {
+        return { isDirectory: () => true } as any;
+      }
+
+      throw new Error(`Unexpected stat path: ${String(filePath)}`);
+    });
+    vi.mocked(glob).mockResolvedValue(["docs/file1.txt"]);
+
+    const agent = new FilesAgent();
+    const result = await agent.gather(["./docs", "!docs/private"], {
+      configSource: "cli",
+    });
+
+    expect(result).toEqual([
+      {
+        tag: "file",
+        attrs: { name: "docs/file1.txt" },
+        content: "File content",
+      },
+    ]);
+    expect(glob).toHaveBeenCalledWith(
+      path.join("./docs", "**", "*"),
+      expect.objectContaining({
+        ignore: expect.arrayContaining(["docs/private/**"]),
+      }),
+    );
+  });
+
+  it("should resolve config directory exclusions relative to config root", async () => {
+    const configDir = "/config";
+
+    vi.mocked(readFile).mockResolvedValue("File content");
+    vi.mocked(stat).mockImplementation(async (filePath) => {
+      if (filePath === "/config/docs" || filePath === "/config/secret") {
+        return { isDirectory: () => true } as any;
+      }
+
+      throw new Error(`Unexpected stat path: ${String(filePath)}`);
+    });
+    vi.mocked(glob).mockResolvedValue(["/config/docs/a.md"]);
+
+    const agent = new FilesAgent();
+    const result = await agent.gather(["./docs", "!./secret"], {
+      configSource: "configFile",
+      configDir,
+    });
+
+    expect(result).toEqual([
+      {
+        tag: "file",
+        attrs: { name: "docs/a.md" },
+        content: "File content",
+      },
+    ]);
+    expect(glob).toHaveBeenCalledWith(
+      path.join("/config/docs", "**", "*"),
+      expect.objectContaining({
+        ignore: expect.arrayContaining(["/config/secret/**"]),
+      }),
+    );
+  });
+
   // New test to demonstrate the bug with command line paths being treated relative to config dir
   it("should not resolve command line paths relative to config dir", async () => {
     const mockFiles = ["docs/file1.txt"];

--- a/src/filesAgent.spec.ts
+++ b/src/filesAgent.spec.ts
@@ -255,6 +255,57 @@ describe("FilesAgent", () => {
     expect(result).toEqual(expected);
   });
 
+  it("should exclude zone identifier files by default", async () => {
+    const mockFiles = [
+      "docs/notes.txt",
+      "docs/notes.txt:Zone.Identifier",
+      "docs/todo.md",
+    ];
+
+    vi.mocked(readFile).mockResolvedValue("File content");
+    vi.mocked(stat).mockImplementation(
+      (filePath) =>
+        Promise.reject(
+          new Error(`No such file or directory: ${String(filePath)}`),
+        ) as any,
+    );
+    vi.mocked(glob).mockImplementation((pattern, options) => {
+      const ignorePatterns = (options.ignore || []) as string[];
+      const shouldIgnoreZoneIdentifier = ignorePatterns.includes(
+        "**/*:Zone.Identifier",
+      );
+
+      return Promise.resolve(
+        mockFiles.filter((filePath) => {
+          if (
+            shouldIgnoreZoneIdentifier &&
+            filePath.endsWith(":Zone.Identifier")
+          ) {
+            return false;
+          }
+
+          return true;
+        }),
+      );
+    });
+
+    const agent = new FilesAgent();
+    const result = await agent.gather(["./docs/**"], { configSource: "cli" });
+
+    expect(result).toEqual([
+      {
+        tag: "file",
+        attrs: { name: "docs/notes.txt" },
+        content: "File content",
+      },
+      {
+        tag: "file",
+        attrs: { name: "docs/todo.md" },
+        content: "File content",
+      },
+    ]);
+  });
+
   it("should treat directory exclusions as recursive ignore patterns", async () => {
     vi.mocked(readFile).mockResolvedValue("File content");
     vi.mocked(stat).mockImplementation(async (filePath) => {

--- a/src/filesAgent.spec.ts
+++ b/src/filesAgent.spec.ts
@@ -6,16 +6,6 @@ import path from "path";
 
 vi.mock("fs/promises");
 vi.mock("glob");
-vi.mock("path", () => {
-  return {
-    default: {
-      join: vi.fn((...parts) => parts.join("/")),
-      parse: vi.fn(),
-      dirname: vi.fn(),
-      relative: vi.fn(),
-    },
-  };
-});
 
 describe("FilesAgent", () => {
   // Unmocked list of default exclusions to match what is in the actual code
@@ -50,7 +40,7 @@ describe("FilesAgent", () => {
     const expected = [
       {
         tag: "file",
-        attrs: { name: "./docs" },
+        attrs: { name: "docs" },
         content: "File content",
       },
     ];
@@ -72,12 +62,12 @@ describe("FilesAgent", () => {
     const expected = [
       {
         tag: "file",
-        attrs: { name: "./docs/file1" },
+        attrs: { name: "docs/file1" },
         content: "File content",
       },
       {
         tag: "file",
-        attrs: { name: "./docs/file2" },
+        attrs: { name: "docs/file2" },
         content: "File content",
       },
     ];
@@ -172,13 +162,13 @@ describe("FilesAgent", () => {
   });
 
   it("should resolve paths relative to baseDir when provided", async () => {
-    const mockFiles = ["docs/file1.txt", "docs/file2.txt"];
     const baseDir = "/config/dir";
     const inputPath = "./docs/file1.txt";
+    const resolvedPath = path.join(baseDir, inputPath);
 
     vi.mocked(readFile).mockResolvedValue("File content");
     vi.mocked(stat).mockResolvedValue({ isDirectory: () => false } as any);
-    vi.mocked(glob).mockResolvedValue([mockFiles[0]]);
+    vi.mocked(glob).mockResolvedValue([resolvedPath]);
 
     const agent = new FilesAgent();
     const result = await agent.gather([inputPath], {
@@ -186,16 +176,13 @@ describe("FilesAgent", () => {
       configSource: "configFile",
     });
 
-    // Verify path.join was called with baseDir
-    expect(path.join).toHaveBeenCalledWith(baseDir, inputPath);
-
     // Verify the file content was read from the correct path
-    expect(readFile).toHaveBeenCalledWith(`${baseDir}/${inputPath}`, "utf-8");
+    expect(readFile).toHaveBeenCalledWith(resolvedPath, "utf-8");
 
     expect(result).toEqual([
       {
         tag: "file",
-        attrs: { name: inputPath }, // Should preserve original path in output
+        attrs: { name: "docs/file1.txt" },
         content: "File content",
       },
     ]);
@@ -218,7 +205,7 @@ describe("FilesAgent", () => {
     expect(result).toEqual([
       {
         tag: "file",
-        attrs: { name: inputPath },
+        attrs: { name: "docs/file1.txt" },
         content: "File content",
       },
     ]);
@@ -289,7 +276,7 @@ describe("FilesAgent", () => {
     expect(cliResult).toEqual([
       {
         tag: "file",
-        attrs: { name: cliPath },
+        attrs: { name: "docs/file1.txt" },
         content: "File content",
       },
     ]);
@@ -301,14 +288,94 @@ describe("FilesAgent", () => {
       configDir,
       configSource: "configFile",
     });
-    expect(readFile).toHaveBeenCalledWith(`${configDir}/${cliPath}`, "utf-8");
+    expect(readFile).toHaveBeenCalledWith(
+      path.join(configDir, cliPath),
+      "utf-8",
+    );
     expect(configResult).toEqual([
       {
         tag: "file",
-        attrs: { name: cliPath },
+        attrs: { name: "docs/file1.txt" },
         content: "File content",
       },
     ]);
+  });
+
+  it("should display expanded config glob matches relative to config dir", async () => {
+    const configDir = "/config";
+
+    vi.mocked(readFile).mockResolvedValue("File content");
+    vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as any);
+    vi.mocked(glob).mockResolvedValue([
+      "/config/docs/file1.txt",
+      "/config/docs/file2.txt",
+    ]);
+
+    const agent = new FilesAgent();
+    const result = await agent.gather(["./docs"], {
+      configDir,
+      configSource: "configFile",
+    });
+
+    expect(result).toEqual([
+      {
+        tag: "file",
+        attrs: { name: "docs/file1.txt" },
+        content: "File content",
+      },
+      {
+        tag: "file",
+        attrs: { name: "docs/file2.txt" },
+        content: "File content",
+      },
+    ]);
+  });
+
+  it("should preserve source-specific path resolution for mixed file options", async () => {
+    const configDir = "/config";
+    const expectedCliDisplayPath = path.relative(
+      configDir,
+      path.resolve("./local.md"),
+    );
+
+    vi.mocked(readFile).mockResolvedValue("File content");
+    vi.mocked(stat).mockImplementation(async (filePath) => {
+      if (filePath === "/config/docs") {
+        return { isDirectory: () => true } as any;
+      }
+
+      if (filePath === "./local.md") {
+        return { isDirectory: () => false } as any;
+      }
+
+      throw new Error(`Unexpected stat path: ${String(filePath)}`);
+    });
+    vi.mocked(glob).mockResolvedValue(["/config/docs/a.md"]);
+
+    const agent = new FilesAgent();
+    const result = await agent.gather(
+      [
+        { path: "./docs", configSource: "configFile", configDir },
+        { path: "./local.md", configSource: "cli" },
+      ],
+      { configDir, configSource: "cli" },
+    );
+
+    expect(result).toEqual([
+      {
+        tag: "file",
+        attrs: { name: "docs/a.md" },
+        content: "File content",
+      },
+      {
+        tag: "file",
+        attrs: { name: expectedCliDisplayPath },
+        content: "File content",
+      },
+    ]);
+
+    expect(readFile).toHaveBeenCalledWith("/config/docs/a.md", "utf-8");
+    expect(readFile).toHaveBeenCalledWith("./local.md", "utf-8");
   });
 
   afterEach(() => {

--- a/src/filesAgent.ts
+++ b/src/filesAgent.ts
@@ -75,11 +75,11 @@ export class FilesAgent implements ReconAgent<FilesAgentOptions> {
     inclusionPatterns: FilePattern[],
     exclusionPatterns: FilePattern[],
   ): Promise<MatchedFilePath[]> {
+    const resolvedExclusions =
+      await this.resolveExclusionPatterns(exclusionPatterns);
+
     const filePathPromises = inclusionPatterns.map(async (pattern) => {
       const resolvedPattern = this.resolvePattern(pattern);
-      const resolvedExclusions = exclusionPatterns.map((exclusionPattern) =>
-        this.resolvePattern(exclusionPattern),
-      );
 
       try {
         const fileStats = await stat(resolvedPattern);
@@ -118,6 +118,30 @@ export class FilesAgent implements ReconAgent<FilesAgentOptions> {
 
     const filePaths = await Promise.all(filePathPromises);
     return filePaths.flat();
+  }
+
+  private async resolveExclusionPatterns(
+    exclusionPatterns: FilePattern[],
+  ): Promise<string[]> {
+    const resolvedExclusions = await Promise.all(
+      exclusionPatterns.map(async (pattern) => {
+        const resolvedPattern = this.resolvePattern(pattern);
+
+        try {
+          const exclusionStats = await stat(resolvedPattern);
+          if (exclusionStats.isDirectory()) {
+            // Treat directory exclusions like inverse directory inclusions.
+            return path.join(resolvedPattern, "**");
+          }
+        } catch {
+          // If the path doesn't exist, keep the exclusion as a glob pattern.
+        }
+
+        return resolvedPattern;
+      }),
+    );
+
+    return resolvedExclusions;
   }
 
   private resolvePattern(pattern: FilePattern): string {

--- a/src/filesAgent.ts
+++ b/src/filesAgent.ts
@@ -9,7 +9,23 @@ import { glob } from "glob";
 import path from "path";
 import { defaultExclusions } from "./defaultExclusions.js";
 
-type FilesAgentOptions = string[];
+export interface SourcedFileOption {
+  path: string;
+  configSource: "configFile" | "cli";
+  configDir?: string;
+}
+
+type FilesAgentOptions = string[] | SourcedFileOption[];
+
+interface FilePattern {
+  pattern: string;
+  configSource: "configFile" | "cli";
+  configDir?: string;
+}
+
+interface MatchedFilePath {
+  filePath: string;
+}
 
 export class FilesAgent implements ReconAgent<FilesAgentOptions> {
   readonly name = "files";
@@ -19,35 +35,51 @@ export class FilesAgent implements ReconAgent<FilesAgentOptions> {
     filesOptions: FilesAgentOptions,
     context: GatherContext,
   ): Promise<GatheredInformation[]> {
+    const normalizedOptions = this.normalizeOptions(filesOptions, context);
+
     // Step 1: Collect all matching file paths with applied exclusions
     const { inclusionPatterns, exclusionPatterns } =
-      this.parsePatterns(filesOptions);
+      this.parsePatterns(normalizedOptions);
     const filePaths = await this.collectFilePathsWithExclusions(
       inclusionPatterns,
       exclusionPatterns,
-      context,
     );
 
     // Step 2: Convert file paths to GatheredInformation
     const gatheredInformation = await this.convertToGatheredInformation(
       filePaths,
-      context.configDir,
-      inclusionPatterns,
+      context.configDir ?? process.cwd(),
     );
 
     return gatheredInformation;
   }
 
-  private async collectFilePathsWithExclusions(
-    inclusionPatterns: string[],
-    exclusionPatterns: string[],
+  private normalizeOptions(
+    options: FilesAgentOptions,
     context: GatherContext,
-  ): Promise<string[]> {
-    const filePathPromises = inclusionPatterns.map(async (pattern) => {
-      let resolvedPattern = pattern;
-      if (context.configSource === "configFile" && context.configDir) {
-        resolvedPattern = path.join(context.configDir, pattern);
+  ): SourcedFileOption[] {
+    return options.map((option) => {
+      if (typeof option === "string") {
+        return {
+          path: option,
+          configSource: context.configSource,
+          configDir: context.configDir,
+        };
       }
+
+      return option;
+    });
+  }
+
+  private async collectFilePathsWithExclusions(
+    inclusionPatterns: FilePattern[],
+    exclusionPatterns: FilePattern[],
+  ): Promise<MatchedFilePath[]> {
+    const filePathPromises = inclusionPatterns.map(async (pattern) => {
+      const resolvedPattern = this.resolvePattern(pattern);
+      const resolvedExclusions = exclusionPatterns.map((exclusionPattern) =>
+        this.resolvePattern(exclusionPattern),
+      );
 
       try {
         const fileStats = await stat(resolvedPattern);
@@ -58,21 +90,29 @@ export class FilesAgent implements ReconAgent<FilesAgentOptions> {
             path.join(resolvedPattern, "**", "*"),
             {
               nodir: true,
-              ignore: [...defaultExclusions, ...exclusionPatterns],
+              ignore: [...defaultExclusions, ...resolvedExclusions],
             },
           );
-          return directoryFiles;
+          return directoryFiles.map((filePath) => ({
+            filePath,
+          }));
         } else {
           // If it's a file path, return it as is
-          return [resolvedPattern];
+          return [
+            {
+              filePath: resolvedPattern,
+            },
+          ];
         }
-      } catch (error) {
+      } catch {
         // If the path is not a file or directory, assume it's a glob pattern
         const matchedPaths = await glob(resolvedPattern, {
           nodir: true,
-          ignore: [...defaultExclusions, ...exclusionPatterns],
+          ignore: [...defaultExclusions, ...resolvedExclusions],
         });
-        return matchedPaths;
+        return matchedPaths.map((filePath) => ({
+          filePath,
+        }));
       }
     });
 
@@ -80,24 +120,25 @@ export class FilesAgent implements ReconAgent<FilesAgentOptions> {
     return filePaths.flat();
   }
 
+  private resolvePattern(pattern: FilePattern): string {
+    if (pattern.configSource === "configFile" && pattern.configDir) {
+      return path.join(pattern.configDir, pattern.pattern);
+    }
+
+    return pattern.pattern;
+  }
+
   private async convertToGatheredInformation(
-    filePaths: string[],
-    baseDir?: string,
-    originalPaths?: string[],
+    filePaths: MatchedFilePath[],
+    displayRootDir: string,
   ): Promise<GatheredInformation[]> {
     const gatheredInformationPromises = filePaths.map(async (filePath) => {
-      const content = await readFile(filePath, "utf-8");
+      const content = await readFile(filePath.filePath, "utf-8");
 
-      // If baseDir is provided, convert absolute paths back to relative paths for display
-      let displayPath = filePath;
-      if (baseDir && originalPaths?.length === 1) {
-        // If there's only one original path, use it directly
-        displayPath = originalPaths[0];
-      } else if (baseDir) {
-        // Otherwise try to make the path relative to baseDir
-        const relativePath = path.relative(baseDir, filePath);
-        displayPath = relativePath.startsWith("..") ? filePath : relativePath;
-      }
+      const absoluteFilePath = path.isAbsolute(filePath.filePath)
+        ? filePath.filePath
+        : path.resolve(filePath.filePath);
+      const displayPath = path.relative(displayRootDir, absoluteFilePath);
 
       const gatheredFileInfo: GatheredInformation = {
         tag: "file",
@@ -113,21 +154,29 @@ export class FilesAgent implements ReconAgent<FilesAgentOptions> {
     return Promise.all(gatheredInformationPromises);
   }
 
-  parseOptions(options: string): FilesAgentOptions {
+  parseOptions(options: string): string[] {
     return options.split(",");
   }
 
-  private parsePatterns(options: FilesAgentOptions) {
-    const inclusionPatterns: string[] = [];
-    const exclusionPatterns: string[] = [];
+  private parsePatterns(options: SourcedFileOption[]) {
+    const inclusionPatterns: FilePattern[] = [];
+    const exclusionPatterns: FilePattern[] = [];
 
     options.forEach((option) => {
-      const path = option;
+      const optionPath = option.path;
 
-      if (path.startsWith("!")) {
-        exclusionPatterns.push(path.slice(1));
+      if (optionPath.startsWith("!")) {
+        exclusionPatterns.push({
+          pattern: optionPath.slice(1),
+          configSource: option.configSource,
+          configDir: option.configDir,
+        });
       } else {
-        inclusionPatterns.push(option);
+        inclusionPatterns.push({
+          pattern: optionPath,
+          configSource: option.configSource,
+          configDir: option.configDir,
+        });
       }
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 import { Command } from "commander";
 import { gatherInformation } from "./gatherInformation.js";
-import { loadConfig, ReconCommand } from "./config.js";
+import { loadConfig } from "./config.js";
 import { writeToFile } from "./fileWriter.js";
 import { FilesAgent } from "./filesAgent.js";
 import { UrlsAgent } from "./urlsAgent.js";
 import { ReconAgent } from "./reconAgent.js";
 import { NotesAgent } from "./notesAgent.js";
 import { FunctionAgent } from "./functionAgent.js";
+import { mergeCommandConfigWithCli } from "./mergeCommandConfig.js";
 
 const program = new Command();
 
@@ -26,7 +27,7 @@ program
       return;
     }
 
-    const { config, configDir } = await loadConfig();
+    const { config, commandConfigDirs, defaultConfigDir } = await loadConfig();
 
     const { commands } = config;
 
@@ -38,42 +39,17 @@ program
       commandConfig = { prompt: options.prompt, gather: {} };
     }
 
-    if (options.prompt) {
-      commandConfig.prompt = options.prompt;
-    }
-
-    // Create a new command config that includes both config file and CLI options
-    const mergedConfig: ReconCommand = {
-      ...commandConfig,
-      gather: { ...commandConfig.gather },
-    };
-
-    // Create a map to track the source of each agent's options
-    const optionsSourceMap: Record<string, "configFile" | "cli"> = {
-      files: "configFile",
-      urls: "configFile",
-    };
-
     const filesAgent = new FilesAgent();
-    if (options.files) {
-      // CLI options are not from config
-      mergedConfig.gather.files = filesAgent.parseOptions(options.files);
-      optionsSourceMap["files"] = "cli"; // CLI options
-    }
-
     const urlsAgent = new UrlsAgent();
-    if (options.urls) {
-      // CLI options are not from config
-      mergedConfig.gather.urls = urlsAgent.parseOptions(options.urls);
-      optionsSourceMap["urls"] = "cli"; // CLI options
-    }
-
-    // Mark config file options with 'configFile'
-    for (const agentName in mergedConfig.gather) {
-      if (!optionsSourceMap[agentName]) {
-        optionsSourceMap[agentName] = "configFile"; // Config file options
-      }
-    }
+    const commandConfigDir =
+      (command ? commandConfigDirs[command] : undefined) || defaultConfigDir;
+    const { mergedConfig, optionsSourceMap } = mergeCommandConfigWithCli(
+      commandConfig,
+      options,
+      filesAgent,
+      urlsAgent,
+      commandConfigDir,
+    );
 
     const agents: ReconAgent<unknown>[] = [
       filesAgent,
@@ -87,7 +63,7 @@ program
       agents,
       mergedConfig,
       optionsSourceMap,
-      configDir,
+      commandConfigDir,
     );
 
     let outputMethods = 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,10 @@ import { ReconAgent } from "./reconAgent.js";
 import { NotesAgent } from "./notesAgent.js";
 import { FunctionAgent } from "./functionAgent.js";
 import { mergeCommandConfigWithCli } from "./mergeCommandConfig.js";
+import { setupBrokenPipeHandler } from "./setupBrokenPipeHandler.js";
 
 const program = new Command();
+setupBrokenPipeHandler(process.stdout);
 
 program
   .description("Gather information for a specific command")

--- a/src/mergeCommandConfig.spec.ts
+++ b/src/mergeCommandConfig.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { FilesAgent } from "./filesAgent";
+import { UrlsAgent } from "./urlsAgent";
+import { mergeCommandConfigWithCli } from "./mergeCommandConfig";
+
+describe("mergeCommandConfigWithCli", () => {
+  it("should merge config and CLI gather options while preserving file option sources", () => {
+    const commandConfig = {
+      prompt: "config prompt",
+      gather: {
+        files: ["./config-docs"],
+        urls: ["https://config.example.com"],
+        notes: "Config note",
+      },
+    };
+
+    const result = mergeCommandConfigWithCli(
+      commandConfig,
+      {
+        prompt: "cli prompt",
+        files: "./cli-doc.md",
+        urls: "https://cli.example.com",
+      },
+      new FilesAgent(),
+      new UrlsAgent(),
+      "/tmp/project",
+    );
+
+    expect(result.mergedConfig.prompt).toBe("cli prompt");
+    expect(result.mergedConfig.gather.files).toEqual([
+      {
+        path: "./config-docs",
+        configSource: "configFile",
+        configDir: "/tmp/project",
+      },
+      {
+        path: "./cli-doc.md",
+        configSource: "cli",
+      },
+    ]);
+    expect(result.mergedConfig.gather.urls).toEqual([
+      "https://config.example.com",
+      "https://cli.example.com",
+    ]);
+    expect(result.optionsSourceMap).toEqual({
+      files: "configFile",
+      urls: "configFile",
+      notes: "configFile",
+    });
+  });
+
+  it("should parse CLI-only gather options and mark their source as cli", () => {
+    const commandConfig = {
+      gather: {},
+    };
+
+    const result = mergeCommandConfigWithCli(
+      commandConfig,
+      {
+        files: "./cli-1.md,./cli-2.md",
+        urls: "https://one.example.com,https://two.example.com",
+      },
+      new FilesAgent(),
+      new UrlsAgent(),
+    );
+
+    expect(result.mergedConfig.gather.files).toEqual([
+      {
+        path: "./cli-1.md",
+        configSource: "cli",
+      },
+      {
+        path: "./cli-2.md",
+        configSource: "cli",
+      },
+    ]);
+    expect(result.mergedConfig.gather.urls).toEqual([
+      "https://one.example.com",
+      "https://two.example.com",
+    ]);
+    expect(result.optionsSourceMap).toEqual({
+      files: "cli",
+      urls: "cli",
+    });
+  });
+});

--- a/src/mergeCommandConfig.ts
+++ b/src/mergeCommandConfig.ts
@@ -1,0 +1,81 @@
+import { ReconCommand } from "./config.js";
+import { FilesAgent, SourcedFileOption } from "./filesAgent.js";
+import { UrlsAgent } from "./urlsAgent.js";
+
+type OptionsSource = "configFile" | "cli";
+
+interface CliOptions {
+  prompt?: string;
+  files?: string;
+  urls?: string;
+}
+
+export function mergeCommandConfigWithCli(
+  commandConfig: ReconCommand,
+  cliOptions: CliOptions,
+  filesAgent: FilesAgent,
+  urlsAgent: UrlsAgent,
+  commandConfigDir?: string,
+): {
+  mergedConfig: ReconCommand;
+  optionsSourceMap: Record<string, OptionsSource>;
+} {
+  const mergedConfig: ReconCommand = {
+    ...commandConfig,
+    gather: { ...commandConfig.gather },
+  };
+
+  if (cliOptions.prompt) {
+    mergedConfig.prompt = cliOptions.prompt;
+  }
+
+  const optionsSourceMap: Record<string, OptionsSource> = {};
+  for (const agentName in mergedConfig.gather) {
+    optionsSourceMap[agentName] = "configFile";
+  }
+
+  const configFiles = normalizeStringArray(mergedConfig.gather.files);
+  const cliFiles = cliOptions.files
+    ? filesAgent.parseOptions(cliOptions.files)
+    : [];
+
+  if (configFiles.length > 0 || cliFiles.length > 0) {
+    const sourcedFileOptions: SourcedFileOption[] = [
+      ...configFiles.map((filePath) => ({
+        path: filePath,
+        configSource: "configFile" as const,
+        configDir: commandConfigDir,
+      })),
+      ...cliFiles.map((filePath) => ({
+        path: filePath,
+        configSource: "cli" as const,
+      })),
+    ];
+
+    mergedConfig.gather.files = sourcedFileOptions;
+    optionsSourceMap.files = configFiles.length > 0 ? "configFile" : "cli";
+  }
+
+  const configUrls = normalizeStringArray(mergedConfig.gather.urls);
+  const cliUrls = cliOptions.urls
+    ? urlsAgent.parseOptions(cliOptions.urls)
+    : [];
+
+  if (configUrls.length > 0 || cliUrls.length > 0) {
+    mergedConfig.gather.urls = [...configUrls, ...cliUrls];
+    optionsSourceMap.urls = configUrls.length > 0 ? "configFile" : "cli";
+  }
+
+  return {
+    mergedConfig,
+    optionsSourceMap,
+  };
+}
+
+function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is string => typeof item === "string");
+}

--- a/src/setupBrokenPipeHandler.spec.ts
+++ b/src/setupBrokenPipeHandler.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { PassThrough } from "stream";
+import { setupBrokenPipeHandler } from "./setupBrokenPipeHandler";
+
+describe("setupBrokenPipeHandler", () => {
+  it("should exit cleanly on EPIPE errors", () => {
+    const stream = new PassThrough() as unknown as NodeJS.WriteStream;
+    const exit = vi.fn();
+
+    setupBrokenPipeHandler(stream, exit);
+
+    const error = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+    stream.emit("error", error);
+
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it("should rethrow non-EPIPE stream errors", () => {
+    const stream = new PassThrough() as unknown as NodeJS.WriteStream;
+    setupBrokenPipeHandler(stream);
+
+    const error = Object.assign(new Error("socket failure"), {
+      code: "ECONNRESET",
+    });
+
+    expect(() => stream.emit("error", error)).toThrow("socket failure");
+  });
+});

--- a/src/setupBrokenPipeHandler.ts
+++ b/src/setupBrokenPipeHandler.ts
@@ -1,0 +1,13 @@
+export function setupBrokenPipeHandler(
+  stream: NodeJS.WriteStream,
+  exit: (code: number) => void = process.exit,
+): void {
+  stream.on("error", (error: NodeJS.ErrnoException) => {
+    if (error.code === "EPIPE") {
+      exit(0);
+      return;
+    }
+
+    throw error;
+  });
+}


### PR DESCRIPTION
## Summary
- Preserve command provenance by tracking which config directory each command came from, plus a default config root.
- Merge CLI files/urls options with command-defined gather values instead of replacing them.
- Add mergeCommandConfigWithCli to centralize merge behavior and source metadata construction.
- Update FilesAgent to support mixed-source file options (config + CLI) while keeping source-specific path resolution.
- Render gathered file names relative to the active config root when one exists; otherwise render relative to current working directory.

## Tests
- Added src/config.spec.ts for home/project config precedence and command directory mapping.
- Added src/mergeCommandConfig.spec.ts for merge semantics and source map behavior.
- Extended src/filesAgent.spec.ts for config-root-relative output naming and mixed-source resolution behavior.
- Ran npm run check successfully.